### PR TITLE
Bugyy model eval whose tensor dimensions don't match

### DIFF
--- a/stompy_live/agents/franka_arm.py
+++ b/stompy_live/agents/franka_arm.py
@@ -52,17 +52,3 @@ class Agent(nn.Module):
         if action is None:
             action = probs.sample()
         return action, probs.log_prob(action).sum(1), probs.entropy().sum(1), self.critic(x)
-
-# Load the model
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-env_kwargs = dict(obs_mode="state", control_mode="pd_joint_delta_pos", render_mode="rgb_array", sim_backend="gpu")
-envs = gym.make("PushCube-v1", num_envs=1, **env_kwargs)
-if isinstance(envs.action_space, gym.spaces.Dict):
-    envs = FlattenActionSpaceWrapper(envs)
-assert isinstance(envs.single_action_space, gym.spaces.Box), "only continuous action space is supported"
-
-agent = Agent(envs).to(device)
-agent.load_state_dict(torch.load("model.pt"))
-while True:
-    action = agent.get_action(torch.tensor([]).to(device))
-    print(action)

--- a/stompy_live/scripts/franka_model.py
+++ b/stompy_live/scripts/franka_model.py
@@ -1,12 +1,14 @@
 """This module is a proof of concept demonstrating how we can plug in the model from model/franka_arm.py"""
 
-import torch
 import gymnasium as gym
+import torch
+from mani_skill.utils.wrappers.flatten import FlattenActionSpaceWrapper
+
 from stompy_live.agents.franka_arm import Agent
 
 # Load the model
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-env_kwargs = dict(obs_mode="state", control_mode="pd_joint_delta_pos", render_mode="rgb_array", sim_backend="gpu")
+env_kwargs = dict(obs_mode="state", control_mode="pd_joint_delta_pos", render_mode="human", sim_backend="gpu")
 envs = gym.make("PushCube-v1", **env_kwargs)
 if isinstance(envs.action_space, gym.spaces.Dict):
     envs = FlattenActionSpaceWrapper(envs)
@@ -14,27 +16,19 @@ assert isinstance(envs.single_action_space, gym.spaces.Box), "only continuous ac
 
 agent = Agent(envs).to(device)
 agent.load_state_dict(torch.load("model.pt"))
-num_episodes = 10
-for episode in range(num_episodes):
+while True:
     agent.eval()
     obs, info = envs.reset()
     done = False
     total_reward = 0
-    
+
     while not done:
-        state = obs['state']
-        # Preprocess the observation
-        obs_tensor = torch.from_numpy(state).float().unsqueeze(0).to(device)
-        
         # Get action from the model
         with torch.no_grad():
-            action = model.act(obs_tensor)
-        
-        # Convert action to numpy and execute in the environment
-        action_np = action.cpu().numpy().squeeze()
-        obs, reward, terminated, truncated, info = env.step(action_np)
-        
+            action = agent.get_action(obs)
+
+        obs, reward, terminated, truncated, info = envs.step(action)
+
         done = terminated or truncated
         total_reward += reward
-
-envs.close()
+        envs.render()

--- a/stompy_live/scripts/franka_model.py
+++ b/stompy_live/scripts/franka_model.py
@@ -1,0 +1,40 @@
+"""This module is a proof of concept demonstrating how we can plug in the model from model/franka_arm.py"""
+
+import torch
+import gymnasium as gym
+from stompy_live.agents.franka_arm import Agent
+
+# Load the model
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+env_kwargs = dict(obs_mode="state", control_mode="pd_joint_delta_pos", render_mode="rgb_array", sim_backend="gpu")
+envs = gym.make("PushCube-v1", **env_kwargs)
+if isinstance(envs.action_space, gym.spaces.Dict):
+    envs = FlattenActionSpaceWrapper(envs)
+assert isinstance(envs.single_action_space, gym.spaces.Box), "only continuous action space is supported"
+
+agent = Agent(envs).to(device)
+agent.load_state_dict(torch.load("model.pt"))
+num_episodes = 10
+for episode in range(num_episodes):
+    agent.eval()
+    obs, info = envs.reset()
+    done = False
+    total_reward = 0
+    
+    while not done:
+        state = obs['state']
+        # Preprocess the observation
+        obs_tensor = torch.from_numpy(state).float().unsqueeze(0).to(device)
+        
+        # Get action from the model
+        with torch.no_grad():
+            action = model.act(obs_tensor)
+        
+        # Convert action to numpy and execute in the environment
+        action_np = action.cpu().numpy().squeeze()
+        obs, reward, terminated, truncated, info = env.step(action_np)
+        
+        done = terminated or truncated
+        total_reward += reward
+
+envs.close()


### PR DESCRIPTION
Requires [2048, 35] tensor rather than the [2048, 28] tensor that the model provides.

The model hass been confirmed to work on the boilerplate stompy_live/scripts/ppo.py script.